### PR TITLE
Prevent pings from stuck while scrolling UIScrollView

### DIFF
--- a/Pod/Classes/SimplePing.m
+++ b/Pod/Classes/SimplePing.m
@@ -630,7 +630,7 @@ static void SocketReadCallback(CFSocketRef s, CFSocketCallBackType type, CFDataR
         rls = CFSocketCreateRunLoopSource(NULL, self.socket, 0);
         assert(rls != NULL);
         
-        CFRunLoopAddSource(CFRunLoopGetCurrent(), rls, kCFRunLoopDefaultMode);
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), rls, kCFRunLoopCommonModes);
         
         CFRelease(rls);
 
@@ -739,7 +739,7 @@ static void HostResolveCallback(CFHostRef theHost, CFHostInfoType typeInfo, cons
     
     CFHostSetClient(self.host, HostResolveCallback, &context);
     
-    CFHostScheduleWithRunLoop(self.host, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+    CFHostScheduleWithRunLoop(self.host, CFRunLoopGetCurrent(), kCFRunLoopCommonModes);
     
     success = CFHostStartInfoResolution(self.host, kCFHostAddresses, &streamError);
     if ( ! success ) {
@@ -754,7 +754,7 @@ static void HostResolveCallback(CFHostRef theHost, CFHostInfoType typeInfo, cons
     // Shut down the CFHost.
     if (self.host != NULL) {
         CFHostSetClient(self.host, NULL, NULL);
-        CFHostUnscheduleFromRunLoop(self.host, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+        CFHostUnscheduleFromRunLoop(self.host, CFRunLoopGetCurrent(), kCFRunLoopCommonModes);
         self.host = NULL;
     }
 }


### PR DESCRIPTION
Main run loop enters into UITrackingRunLoopMode which prevents handling of events scheduled for default mode.