### PR TITLE
didReceiveUnexpectedPacket causing memory leaks

### DIFF
--- a/PlainPing.podspec
+++ b/PlainPing.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "PlainPing"
-  s.version          = "0.5"
+  s.version          = "0.5.1"
   s.summary          = "a very plain ping interface in swift"
 
   # s.description      = <<-DESC

--- a/Pod/Classes/SimplePing.m
+++ b/Pod/Classes/SimplePing.m
@@ -526,9 +526,12 @@ static uint16_t in_cksum(const void *buffer, size_t bufferLen) {
                 [strongDelegate simplePing:self didReceivePingResponsePacket:packet sequenceNumber:sequenceNumber];
             }
         } else {
-            if ( (strongDelegate != nil) && [strongDelegate respondsToSelector:@selector(simplePing:didReceiveUnexpectedPacket:)] ) {
-                [strongDelegate simplePing:self didReceiveUnexpectedPacket:packet];
-            }
+
+// NOTE: Patching the pod source. This call doesn't return a delegate call (SimplePingAdapter.swift didReceiveUnexpectedPacket) and it's caller doesn't release objects due to the missing delegate call.  We're commenting this out to just allow this case to fallback on the timeoutTimer functionality and it cleans up properly. It's causing a memory leak.
+            
+//            if ( (strongDelegate != nil) && [strongDelegate respondsToSelector:@selector(simplePing:didReceiveUnexpectedPacket:)] ) {
+//                [strongDelegate simplePing:self didReceiveUnexpectedPacket:packet];
+//            }
         }
     } else {
     


### PR DESCRIPTION
We identified that the commented out code in this PR was causing memory leaks.  If you look at the call stack after that, the second delegate isn't calling back to clean up the objects created. For now, we just commented out the code and allow the Timer to be hit and thus calling the delegate to cleanly drop out.  I wasn't sure what the need for this didReceiveUnexpectedPacket is there to detect.  I would be fine with keeping it, but it's not calling the delegate and cleaning up objects.