### PR TITLE
Crash prevention from assert( CFSocketGetSocketFlags(self.socket) & kCFSocketCloseOnInvalidate );

### DIFF
--- a/PlainPing.podspec
+++ b/PlainPing.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "PlainPing"
-  s.version          = "0.5"
+  s.version          = "0.5.1"
   s.summary          = "a very plain ping interface in swift"
 
   # s.description      = <<-DESC

--- a/Pod/Classes/SimplePing.m
+++ b/Pod/Classes/SimplePing.m
@@ -526,9 +526,12 @@ static uint16_t in_cksum(const void *buffer, size_t bufferLen) {
                 [strongDelegate simplePing:self didReceivePingResponsePacket:packet sequenceNumber:sequenceNumber];
             }
         } else {
-            if ( (strongDelegate != nil) && [strongDelegate respondsToSelector:@selector(simplePing:didReceiveUnexpectedPacket:)] ) {
-                [strongDelegate simplePing:self didReceiveUnexpectedPacket:packet];
-            }
+
+// NOTE: Patching the pod source. This call doesn't return a delegate call (SimplePingAdapter.swift didReceiveUnexpectedPacket) and it's caller doesn't release objects due to the missing delegate call.  We're commenting this out to just allow this case to fallback on the timeoutTimer functionality and it cleans up properly. It's causing a memory leak.
+            
+//            if ( (strongDelegate != nil) && [strongDelegate respondsToSelector:@selector(simplePing:didReceiveUnexpectedPacket:)] ) {
+//                [strongDelegate simplePing:self didReceiveUnexpectedPacket:packet];
+//            }
         }
     } else {
     

--- a/Pod/Classes/SimplePing.m
+++ b/Pod/Classes/SimplePing.m
@@ -627,7 +627,17 @@ static void SocketReadCallback(CFSocketRef s, CFSocketCallBackType type, CFDataR
         
         // The socket will now take care of cleaning up our file descriptor.
         
-        assert( CFSocketGetSocketFlags(self.socket) & kCFSocketCloseOnInvalidate );
+        CFSocketSetSocketFlags(self.socket, kCFSocketCloseOnInvalidate);
+               
+        if (!CFSocketGetSocketFlags(self.socket)) {
+           [self didFailWithError:[NSError errorWithDomain:NSPOSIXErrorDomain code:err userInfo:@{NSLocalizedDescriptionKey:@"Invalid socket flags"}]];
+           return;
+        }
+        else if (!kCFSocketCloseOnInvalidate) {
+           [self didFailWithError:[NSError errorWithDomain:NSPOSIXErrorDomain code:err userInfo:@{NSLocalizedDescriptionKey:@"Invalid socket close"}]];
+           return;
+        }
+               
         fd = -1;
         
         rls = CFSocketCreateRunLoopSource(NULL, self.socket, 0);


### PR DESCRIPTION
We swapped out the assert because we're getting crashes on the following line:

assert( CFSocketGetSocketFlags(self.socket) & kCFSocketCloseOnInvalidate );


Instead we're using if / else if statements and if found present, then we return an error and let the caller get an error back from a ping response on the Swift side.