### PR TITLE
Disabled automatic objective-c compatibility header generation

### DIFF
--- a/PlainPing.podspec
+++ b/PlainPing.podspec
@@ -17,6 +17,8 @@ Pod::Spec.new do |s|
 
   s.platforms    = { :ios => "8.0", :osx => "10.11" }
   s.requires_arc = true
+  
+  s.xcconfig = { 'SWIFT_INSTALL_OBJC_HEADER' => 'NO' }
 
   s.source_files = 'Pod/Classes/**/*'
   #s.resource_bundles = {


### PR DESCRIPTION
Since xcode has by default  SWIFT_INSTALL_OBJC_HEADER = YES, compiler is generating header for objective c. This is not needed and even breaks build as the generated header is not compiling due to incorrect import.